### PR TITLE
feat: Add groups and federated_id claims to the scope

### DIFF
--- a/pkg/proxy/config.go
+++ b/pkg/proxy/config.go
@@ -93,7 +93,7 @@ cookie_httponly = {{.Cookie.HTTPOnly}}
 ## Provider Specific Configurations
 provider = "oidc"
 oidc_issuer_url = "{{.OIDCIssuerURL}}"
-scope = "openid email profile"
+scope = "openid email profile groups federated:id"
 skip_provider_button = true
 `
 


### PR DESCRIPTION
federated_id is a dex specific that passes down the username and
connector used which is much easier to work with than the sub that dex
uses.

Whilst I was here add Groups because it may be useful to someone