### PR TITLE
Refs jenkins-x/sso-operator#22

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ spec:
   forwardToken: false
   domain: "example.com"
   certIssuerName: "letsencrypt-prod"
+  urlTemplate: "{{.Service}}.{{.Namespace}}.{{.Domain}}"
   cookieSpec:
     name: "sso-golang-http"
     expire: "168h"

--- a/examples/sso.yaml
+++ b/examples/sso.yaml
@@ -9,6 +9,7 @@ spec:
   forwardToken: true
   domain: "exmaple.com"
   certIssuerName: "letsencrypt-prod"
+  urlTemplate: "{{.Service}}.{{.Namespace}}.{{.Domain}}"
   cookieSpec:
     name: "sso-golang-http"
     expire: "168h"

--- a/pkg/apis/jenkins.io/v1/types.go
+++ b/pkg/apis/jenkins.io/v1/types.go
@@ -42,8 +42,8 @@ type SSOSpec struct {
 	ForwardToken bool `json:"forwardToken,omitempty"`
 	// CookieSpec cookie specifications
 	CookieSpec CookieSpec `json:"cookieSpec,omitempty"`
-	// UrlTemplate to use in the exposecontroller configMap
-	UrlTemplate string `json:"urlTemplate,omitempty"`
+	// URLTemplate to use in the exposecontroller configMap
+	URLTemplate string `json:"urlTemplate,omitempty"`
 }
 
 // CookieSpec is the specification of a cookie for a Single Sign-On resource

--- a/pkg/apis/jenkins.io/v1/types.go
+++ b/pkg/apis/jenkins.io/v1/types.go
@@ -42,6 +42,8 @@ type SSOSpec struct {
 	ForwardToken bool `json:"forwardToken,omitempty"`
 	// CookieSpec cookie specifications
 	CookieSpec CookieSpec `json:"cookieSpec,omitempty"`
+	// UrlTemplate to use in the exposecontroller configMap
+	UrlTemplate string `json:"urlTemplate,omitempty"`
 }
 
 // CookieSpec is the specification of a cookie for a Single Sign-On resource

--- a/pkg/proxy/expose.go
+++ b/pkg/proxy/expose.go
@@ -220,6 +220,7 @@ func exposeConfigMap(sso *apiv1.SSO, serviceName string) (*v1.ConfigMap, error) 
 		HTTP:     false,
 		TLSAcme:  true,
 		Services: []string{serviceName},
+		UrlTemplate: sso.Spec.UrlTemplate,
 	}
 
 	config, err := renderExposeConfig(exposeConfig)
@@ -250,6 +251,7 @@ type ExposeConfig struct {
 	HTTP     bool     `yaml:"http" json:"http"`
 	TLSAcme  bool     `yaml:"tls-acme" json:"tls_acme"`
 	Services []string `yaml:"services,omitempty" json:"services"`
+	UrlTemplate string `yaml:"urltemplate,omitempty" json:"urltemplate"`
 }
 
 func renderExposeConfig(config *ExposeConfig) (string, error) {

--- a/pkg/proxy/expose.go
+++ b/pkg/proxy/expose.go
@@ -214,13 +214,13 @@ func cleanupContainer(sso *apiv1.SSO, filter string) *v1.Container {
 
 func exposeConfigMap(sso *apiv1.SSO, serviceName string) (*v1.ConfigMap, error) {
 	exposeConfig := &ExposeConfig{
-		Domain:   sso.Spec.Domain,
-		Exposer:  exposer,
-		PathMode: "",
-		HTTP:     false,
-		TLSAcme:  true,
-		Services: []string{serviceName},
-		UrlTemplate: sso.Spec.UrlTemplate,
+		Domain:      sso.Spec.Domain,
+		Exposer:     exposer,
+		PathMode:    "",
+		HTTP:        false,
+		TLSAcme:     true,
+		Services:    []string{serviceName},
+		URLTemplate: sso.Spec.URLTemplate,
 	}
 
 	config, err := renderExposeConfig(exposeConfig)
@@ -245,13 +245,13 @@ func exposeConfigMap(sso *apiv1.SSO, serviceName string) (*v1.ConfigMap, error) 
 
 // ExposeConfig holds the configuration for exposecontroller
 type ExposeConfig struct {
-	Domain   string   `yaml:"domain,omitempty" json:"domain"`
-	Exposer  string   `yaml:"exposer" json:"exposer"`
-	PathMode string   `yaml:"path-mode" json:"path_mode"`
-	HTTP     bool     `yaml:"http" json:"http"`
-	TLSAcme  bool     `yaml:"tls-acme" json:"tls_acme"`
-	Services []string `yaml:"services,omitempty" json:"services"`
-	UrlTemplate string `yaml:"urltemplate,omitempty" json:"urltemplate"`
+	Domain      string   `yaml:"domain,omitempty" json:"domain"`
+	Exposer     string   `yaml:"exposer" json:"exposer"`
+	PathMode    string   `yaml:"path-mode" json:"path_mode"`
+	HTTP        bool     `yaml:"http" json:"http"`
+	TLSAcme     bool     `yaml:"tls-acme" json:"tls_acme"`
+	Services    []string `yaml:"services,omitempty" json:"services"`
+	URLTemplate string   `yaml:"urltemplate,omitempty" json:"urltemplate"`
 }
 
 func renderExposeConfig(config *ExposeConfig) (string, error) {

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,9 +85,9 @@ func labels(sso *apiv1.SSO, appName string) map[string]string {
 }
 
 func serviceAnnotations(sso *apiv1.SSO, appName string) map[string]string {
-	expIngressAnnotation := ingressClassAnnotations + ": " + ingressClass;
+	expIngressAnnotation := ingressClassAnnotations + ": " + ingressClass
 	if len(sso.Spec.CertIssuerName) != 0 {
-		expIngressAnnotation += "\n" + certManagerAnnotation + ": " + sso.Spec.CertIssuerName;
+		expIngressAnnotation += "\n" + certManagerAnnotation + ": " + sso.Spec.CertIssuerName
 	}
 	return map[string]string{
 		exposeAnnotation:        "true",

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,7 +85,7 @@ func labels(sso *apiv1.SSO, appName string) map[string]string {
 }
 
 func serviceAnnotations(sso *apiv1.SSO, appName string) map[string]string {
-	var expIngressAnnotation string = ingressClassAnnotations + ": " + ingressClass;
+	expIngressAnnotation := ingressClassAnnotations + ": " + ingressClass;
 	if len(sso.Spec.CertIssuerName) != 0 {
 		expIngressAnnotation += "\n" + certManagerAnnotation + ": " + sso.Spec.CertIssuerName;
 	}

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -85,10 +85,14 @@ func labels(sso *apiv1.SSO, appName string) map[string]string {
 }
 
 func serviceAnnotations(sso *apiv1.SSO, appName string) map[string]string {
+	var expIngressAnnotation string = ingressClassAnnotations + ": " + ingressClass;
+	if len(sso.Spec.CertIssuerName) != 0 {
+		expIngressAnnotation += "\n" + certManagerAnnotation + ": " + sso.Spec.CertIssuerName;
+	}
 	return map[string]string{
 		exposeAnnotation:        "true",
 		ingressNameAnnotation:   appName,
-		exposeIngressAnnotation: ingressClassAnnotations + ": " + ingressClass + "\n" + certManagerAnnotation + ": " + sso.Spec.CertIssuerName,
+		exposeIngressAnnotation: expIngressAnnotation,
 	}
 }
 


### PR DESCRIPTION
Added UrlTemplate to SSO.Spec to allow setting the urltemplate in the exposeconttroller configmap
Added a check to not add ingress annotation if CertIssuerName is not defined in the SSO.Spec