### PR TITLE
chore: Ensure k8s resource names are not more than 63 chars

### DIFF
--- a/pkg/proxy/expose.go
+++ b/pkg/proxy/expose.go
@@ -135,11 +135,11 @@ func Cleanup(sso *apiv1.SSO, serviceName string, serviceAccount string) error {
 
 func createJob(name string, sso *apiv1.SSO, serviceAccount string, container *v1.Container) *batchv1.Job {
 	ns := sso.GetNamespace()
-	name = fmt.Sprintf("%s-%s", buildName(sso.GetName(), ns), name)
+	jobName := buildName(sso.GetName(), name)
 
 	podTempl := v1.PodTemplateSpec{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      jobName,
 			Namespace: ns,
 		},
 		Spec: v1.PodSpec{
@@ -165,7 +165,7 @@ func createJob(name string, sso *apiv1.SSO, serviceAccount string, container *v1
 			APIVersion: "batch/v1",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      name,
+			Name:      jobName,
 			Namespace: ns,
 		},
 		Spec: batchv1.JobSpec{
@@ -176,7 +176,7 @@ func createJob(name string, sso *apiv1.SSO, serviceAccount string, container *v1
 
 func exposeContainer(sso *apiv1.SSO) *v1.Container {
 	return &v1.Container{
-		Name:            fmt.Sprintf("%s-expose", sso.GetName()),
+		Name:            buildName(sso.GetName(), "expose"),
 		Image:           fmt.Sprintf("%s:%s", exposeImage, exposeImageTag),
 		ImagePullPolicy: v1.PullIfNotPresent,
 		Command:         []string{exposeCmd},
@@ -195,7 +195,7 @@ func exposeContainer(sso *apiv1.SSO) *v1.Container {
 
 func cleanupContainer(sso *apiv1.SSO, filter string) *v1.Container {
 	return &v1.Container{
-		Name:            fmt.Sprintf("%s-cleanup", sso.GetName()),
+		Name:            buildName(sso.GetName(), "cleanup"),
 		Image:           fmt.Sprintf("%s:%s", exposeImage, exposeImageTag),
 		ImagePullPolicy: v1.PullIfNotPresent,
 		Command:         []string{exposeCmd},

--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -76,10 +76,20 @@ func ConvertHostsToRedirectURLs(hosts []string, sso *apiv1.SSO) []string {
 	return redirectURLs
 }
 
+// buildName concatenates resourceName and suffix equally with a max length of 63 chars
 func buildName(resourceName string, suffix string) string {
 	name := resourceName
-	if len(resourceName) > 62-len(suffix) {
-		name = strings.TrimSuffix(name[0:62-len(suffix)], "-")
+
+	maxLenName := 62
+	maxLenOnePart := maxLenName / 2
+	switch {
+	case len(suffix) > maxLenOnePart && len(name) > maxLenOnePart:
+		name = strings.TrimSuffix(name[:maxLenOnePart], "-")
+		suffix = strings.TrimSuffix(suffix[:maxLenOnePart], "-")
+	case len(suffix) > maxLenOnePart && len(name) < maxLenOnePart:
+		suffix = strings.TrimSuffix(suffix[:62-len(name)], "-")
+	case len(suffix) < maxLenOnePart && len(name) > maxLenOnePart:
+		name = strings.TrimSuffix(name[:maxLenName-len(suffix)], "-")
 	}
 
 	if suffix != "" {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -1,0 +1,76 @@
+package proxy
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestBuildNameResource(t *testing.T) {
+	// 4 chars resource name
+	resourceName := "name"
+	// 6 chars suffix
+	suffix := "suffix"
+
+	expectedName := "name-suffix"
+
+	name := buildName(resourceName, suffix)
+
+	assert.Equal(t, 11, len(name))
+	assert.Equal(t, expectedName, name)
+}
+
+func TestBuildNameResourceNameMoreThan63Chars(t *testing.T) {
+	// 65 chars resource name
+	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffffffff"
+	// 6 chars suffix
+	suffix := "suffix"
+
+	expectedName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-f-suffix"
+
+	name := buildName(resourceName, suffix)
+
+	assert.Equal(t, 63, len(name))
+	assert.Equal(t, expectedName, name)
+}
+
+func TestBuildNameSuffixMoreThan63Chars(t *testing.T) {
+	// 4 chars name
+	resourceName := "name"
+	// 65 chars resource name
+	suffix := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffffffff"
+
+	expectedName := "name-aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-fff"
+
+	name := buildName(resourceName, suffix)
+
+	assert.Equal(t, 63, len(name))
+	assert.Equal(t, expectedName, name)
+}
+
+func TestBuildNameResourceNameAndSuffixMoreThan63Chars(t *testing.T) {
+	// 65 chars resource name
+	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffffffff"
+	// 65 chars resource name
+	suffix := "gggggggggg-hhhhhhhhhh-iiiiiiiiii-jjjjjjjjjj-kkkkkkkkkk-llllllllll"
+
+	expectedName := "aaaaaaaaaa-bbbbbbbbbb-ccccccccc-gggggggggg-hhhhhhhhhh-iiiiiiiii"
+
+	name := buildName(resourceName, suffix)
+
+	assert.Equal(t, 63, len(name))
+	assert.Equal(t, expectedName, name)
+}
+
+func TestBuildNameTrailingDash(t *testing.T) {
+	// 65 chars resource name
+	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffff"
+	// 7 chars suffix
+	suffix := "sufffix"
+
+	expectedName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-sufffix"
+
+	name := buildName(resourceName, suffix)
+
+	assert.Equal(t, 62, len(name))
+	assert.Equal(t, expectedName, name)
+}


### PR DESCRIPTION
Fixing https://github.com/jenkins-x/sso-operator/issues/24

This fix contains some small refactor on the actual resource names.
I validated it in a test cluster but feel free to let me know if it could have any side effect that I could have missed.