### PR TITLE
chore: Add missing simple cases to proxy buildName function

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -83,6 +83,10 @@ func buildName(resourceName string, suffix string) string {
 	maxLenName := 62
 	maxLenOnePart := maxLenName / 2
 	switch {
+	case len(suffix) > 0 && len(name)+len(suffix) < maxLenName:
+		return fmt.Sprintf("%s-%s", name, suffix)
+	case len(suffix) == 0 && len(name) < maxLenName:
+		return name
 	case len(suffix) > maxLenOnePart && len(name) > maxLenOnePart:
 		name = strings.TrimSuffix(name[:maxLenOnePart], "-")
 		suffix = strings.TrimSuffix(suffix[:maxLenOnePart], "-")
@@ -90,6 +94,8 @@ func buildName(resourceName string, suffix string) string {
 		suffix = strings.TrimSuffix(suffix[:62-len(name)], "-")
 	case len(suffix) < maxLenOnePart && len(name) > maxLenOnePart:
 		name = strings.TrimSuffix(name[:maxLenName-len(suffix)], "-")
+	case len(name) > maxLenName+1:
+		name = strings.TrimSuffix(name[:maxLenName], "-")
 	}
 
 	if suffix != "" {

--- a/pkg/proxy/proxy_test.go
+++ b/pkg/proxy/proxy_test.go
@@ -6,16 +6,16 @@ import (
 )
 
 func TestBuildNameResource(t *testing.T) {
-	// 4 chars resource name
-	resourceName := "name"
+	// 43 chars resource name
+	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd"
 	// 6 chars suffix
 	suffix := "suffix"
 
-	expectedName := "name-suffix"
+	expectedName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-suffix"
 
 	name := buildName(resourceName, suffix)
 
-	assert.Equal(t, 11, len(name))
+	assert.Equal(t, 50, len(name))
 	assert.Equal(t, expectedName, name)
 }
 
@@ -36,7 +36,7 @@ func TestBuildNameResourceNameMoreThan63Chars(t *testing.T) {
 func TestBuildNameSuffixMoreThan63Chars(t *testing.T) {
 	// 4 chars name
 	resourceName := "name"
-	// 65 chars resource name
+	// 65 chars suffix
 	suffix := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffffffff"
 
 	expectedName := "name-aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-fff"
@@ -50,7 +50,7 @@ func TestBuildNameSuffixMoreThan63Chars(t *testing.T) {
 func TestBuildNameResourceNameAndSuffixMoreThan63Chars(t *testing.T) {
 	// 65 chars resource name
 	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffffffff"
-	// 65 chars resource name
+	// 65 chars suffix
 	suffix := "gggggggggg-hhhhhhhhhh-iiiiiiiiii-jjjjjjjjjj-kkkkkkkkkk-llllllllll"
 
 	expectedName := "aaaaaaaaaa-bbbbbbbbbb-ccccccccc-gggggggggg-hhhhhhhhhh-iiiiiiiii"
@@ -62,12 +62,40 @@ func TestBuildNameResourceNameAndSuffixMoreThan63Chars(t *testing.T) {
 }
 
 func TestBuildNameTrailingDash(t *testing.T) {
-	// 65 chars resource name
+	// 61 chars resource name
 	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffff"
 	// 7 chars suffix
 	suffix := "sufffix"
 
 	expectedName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-sufffix"
+
+	name := buildName(resourceName, suffix)
+
+	assert.Equal(t, 62, len(name))
+	assert.Equal(t, expectedName, name)
+}
+
+func TestBuildNameNoSuffix(t *testing.T) {
+	// 43 chars resource name
+	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd"
+	// Empty string suffix
+	suffix := ""
+
+	expectedName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd"
+
+	name := buildName(resourceName, suffix)
+
+	assert.Equal(t, 43, len(name))
+	assert.Equal(t, expectedName, name)
+}
+
+func TestBuildNameNoSuffixLongResourceName(t *testing.T) {
+	// 65 chars resource name
+	resourceName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-ffffffffff"
+	// Empty string suffix
+	suffix := ""
+
+	expectedName := "aaaaaaaaaa-bbbbbbbbbb-cccccccccc-dddddddddd-eeeeeeeeee-fffffff"
 
 	name := buildName(resourceName, suffix)
 


### PR DESCRIPTION
Follow up https://github.com/jenkins-x/sso-operator/pull/25.
There was 2 missing cases not handled by the buildName function.