### PR TITLE
fix: Use certmanager v1alpha2 APIs by default

### DIFF
--- a/charts/sso-operator/templates/cert-grpc-client.yaml
+++ b/charts/sso-operator/templates/cert-grpc-client.yaml
@@ -1,5 +1,9 @@
 {{ $fullname := include "fullname" . }}
+  {{- if .Values.certs.legacyApi }}
 apiVersion: certmanager.k8s.io/v1alpha1
+  {{- else }}
+apiVersion: cert-manager.io/v1alpha2
+  {{- end }}
 kind: Certificate
 metadata:
   name: {{ $fullname }}-grpc-client-cert

--- a/charts/sso-operator/values.yaml
+++ b/charts/sso-operator/values.yaml
@@ -33,6 +33,9 @@ terminationGracePeriodSeconds: 10
 watch:
   namespace: "" # if the namespace is empty, it will watch the entire cluster
 
+certs:
+  legacyApi: false
+
 dex:
   grpcHost: dex.sso
   grpcPort: 5000 


### PR DESCRIPTION
See https://github.com/jenkins-x/dex/pull/25 for why I'm doing this as
default, but we need v1alpha2 for anything running cert-manager 0.11,
which at this point means any relatively up-to-date instance.

Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>