### PR TITLE
fix: Use valid and more current oauth_proxy2 image tag in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ spec:
     secure: true
     httpOnly: true
   proxyImage: "quay.io/pusher/oauth2_proxy"
-  proxyImageTag: "3.1.0"
+  proxyImageTag: "v3.2.0"
   proxyResources:
     limits:
       cpu: 100m

--- a/examples/sso.yaml
+++ b/examples/sso.yaml
@@ -17,7 +17,7 @@ spec:
     secure: true
     httpOnly: true
   proxyImage: "quay.io/pusher/oauth2_proxy"
-  proxyImageTag: "3.1.0"
+  proxyImageTag: "v3.2.0"
   proxyResources:
     limits:
       cpu: 100m


### PR DESCRIPTION
Signed-off-by: Andrew Bayer <andrew.bayer@gmail.com>