### PR TITLE
fix: Allow multiple secrets in one namespace

### DIFF
--- a/pkg/proxy/proxy.go
+++ b/pkg/proxy/proxy.go
@@ -152,7 +152,7 @@ func Deploy(sso *apiv1.SSO, oidcClient *api.Client, cookieSecret string) (*Proxy
 				Name: configVolumeName,
 				VolumeSource: v1.VolumeSource{
 					Secret: &v1.SecretVolumeSource{
-						SecretName: configSecretName,
+						SecretName: buildName(sso.GetName(), configSecretName),
 					},
 				},
 			}},
@@ -442,7 +442,7 @@ func proxySecret(sso *apiv1.SSO, client *api.Client, cookieSecret string, labels
 			Kind:       "Secret",
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      configSecretName,
+			Name:      buildName(sso.GetName(), configSecretName),
 			Namespace: sso.Namespace,
 			Labels:    labels,
 		},


### PR DESCRIPTION
Current code uses a fixed name "proxy-secret" for all instantiations of an SSO 
resource.  This causes conflicts when there are multiple SSO resources in a namespace.

This PR uses the existing "buildName" function to ensure naming based on the SSO name.