### PR TITLE
Helm chart: Allow changing the certificate issuer 'Kind' to support ClusterIssuers

### DIFF
--- a/charts/sso-operator/templates/cert-grpc-client.yaml
+++ b/charts/sso-operator/templates/cert-grpc-client.yaml
@@ -14,7 +14,7 @@ spec:
   secretName: {{ .Values.dex.certs.grpc.client.secretName }}
   issuerRef:
     name: {{ .Values.dex.certs.grpc.issuer.name }}
-    kind: Issuer
+    kind: {{ .Values.dex.certs.grpc.issuer.kind }}
   commonName: dex-grpc-client
   dnsName:
   - {{ .Values.dex.grpcHost }}

--- a/charts/sso-operator/values.yaml
+++ b/charts/sso-operator/values.yaml
@@ -43,5 +43,6 @@ dex:
     grpc:
       issuer:
         name: dex-grpc-cert-issuer
+        kind: Issuer
       client:
         secretName: dex-grpc-client-cert


### PR DESCRIPTION
Default is still 'Issuer'