### PR TITLE
fix: use of k8s API to read secret Data field

### DIFF
--- a/pkg/operator/config.go
+++ b/pkg/operator/config.go
@@ -3,7 +3,7 @@ package operator
 import (
 	"github.com/jenkins-x/sso-operator/pkg/kubernetes"
 	"github.com/pkg/errors"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,7 +35,7 @@ func getOperatorConfigFromSecret(namespace string) (*operatorConfig, error) {
 		return nil, errors.Wrap(err, "cleaning up the operator config secret due to error")
 	}
 
-	cookieKey, ok := secret.StringData[ssoCookieKey]
+	cookieKey, ok := secret.Data[ssoCookieKey]
 	if !ok {
 		delerr := deleteOperatorConfigSecret(namespace)
 		if delerr != nil {
@@ -45,7 +45,7 @@ func getOperatorConfigFromSecret(namespace string) (*operatorConfig, error) {
 	}
 
 	return &operatorConfig{
-		ssoCookieKey: cookieKey,
+		ssoCookieKey: string(cookieKey),
 	}, nil
 }
 

--- a/pkg/operator/operator.go
+++ b/pkg/operator/operator.go
@@ -17,6 +17,7 @@ import (
 func NewHandler(dexClient *dex.Client, namespace string, clusterRoleName string) (sdk.Handler, error) {
 	config, err := getOperatorConfigFromSecret(namespace)
 	if err != nil {
+		logrus.Info("unable to fetch existing cookie key: " + err.Error())
 		logrus.Info("operator generating the cookie key")
 		ssoCookieKey, err := proxy.GenerateCookieKey()
 		if err != nil {
@@ -29,6 +30,8 @@ func NewHandler(dexClient *dex.Client, namespace string, clusterRoleName string)
 		if err != nil {
 			return nil, errors.Wrap(err, "storing the operator config in a secret")
 		}
+	} else {
+		logrus.Info("operator using existing cookie key")
 	}
 	return &Handler{
 		dexClient:       dexClient,


### PR DESCRIPTION
StringData is a write-only field and is not output by the API.  Instead, we need to read the Data field and convert to a string.  

Also adds some small logging to emit errors if any are found.